### PR TITLE
US601024: Bring Java Adapter SDK back into sync with .NET version

### DIFF
--- a/src/main/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/AdapterApiImpl.java
+++ b/src/main/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/AdapterApiImpl.java
@@ -63,7 +63,7 @@ final class AdapterApiImpl implements AdapterApi
         final RetrieveFileDataResponse response = new RetrieveFileDataResponse();
 
         repositoryAdapter.retrieveFilesData(
-            new RetrieveFilesDataRequestImpl(request),
+            new RepositoryFilesRequestImpl(request),
             new FileDataResultsHandlerImpl(response),
             StandardCancellationTokens.UNCANCELABLE);
 

--- a/src/main/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/FileMetadataImpl.java
+++ b/src/main/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/FileMetadataImpl.java
@@ -56,7 +56,7 @@ final class FileMetadataImpl implements FileMetadata
     }
 
     @Override
-    public long getSize()
+    public Long getSize()
     {
         return metadata.getSize();
     }

--- a/src/main/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/RepositoryFilesRequestImpl.java
+++ b/src/main/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/RepositoryFilesRequestImpl.java
@@ -17,15 +17,15 @@ package io.github.fileanalysissuite.adaptersdk.impls.jaxrs;
 
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RepositoryFile;
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RepositoryProperties;
-import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RetrieveFilesDataRequest;
+import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RepositoryFilesRequest;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 
-final class RetrieveFilesDataRequestImpl implements RetrieveFilesDataRequest
+final class RepositoryFilesRequestImpl implements RepositoryFilesRequest
 {
     private final io.github.fileanalysissuite.adaptersdk.impls.jaxrs.internal.serverstubs.model.RetrieveFileDataRequest request;
 
-    public RetrieveFilesDataRequestImpl(
+    public RepositoryFilesRequestImpl(
         final io.github.fileanalysissuite.adaptersdk.impls.jaxrs.internal.serverstubs.model.RetrieveFileDataRequest request
     )
     {

--- a/src/test/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/AdapterSDKFakeTest.java
+++ b/src/test/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/AdapterSDKFakeTest.java
@@ -97,7 +97,7 @@ final class AdapterSDKFakeTest extends JerseyTest
         assertThat(failureDetails, equalTo(actualRetrieveFileListResponse.getFailures()));
         final List<FileListItem> files = actualRetrieveFileListResponse.getFiles();
         final FileListItem item = files.get(0);
-        assertThat(files.size(), equalTo(1));
+        assertThat(((long) files.size()), equalTo(1L));
         assertThat(item.getPartitionHint(), equalTo("-"));
         assertThat(item.getFileMetadata(), equalTo(fileMetadata));
     }

--- a/src/test/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/FakeRepositoryAdapter.java
+++ b/src/test/java/io/github/fileanalysissuite/adaptersdk/impls/jaxrs/FakeRepositoryAdapter.java
@@ -27,7 +27,7 @@ import io.github.fileanalysissuite.adaptersdk.interfaces.framework.FileListResul
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.OptionsProvider;
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RepositoryFile;
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RetrieveFileListRequest;
-import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RetrieveFilesDataRequest;
+import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RepositoryFilesRequest;
 import io.github.fileanalysissuite.adaptersdk.interfaces.extensibility.FileMetadata;
 import io.github.fileanalysissuite.adaptersdk.convenience.ConvenientRepositorySettingDefinition;
 import io.github.fileanalysissuite.adaptersdk.interfaces.extensibility.RepositorySettingDefinition;
@@ -77,7 +77,7 @@ final class FakeRepositoryAdapter implements RepositoryAdapter
 
     @Override
     public void retrieveFilesData(
-        final RetrieveFilesDataRequest request,
+        final RepositoryFilesRequest request,
         final FileDataResultsHandler handler,
         final CancellationToken cancellationToken
     )


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=601024

Renamed references of RetrieveFilesDataRequest to RepositoryFilesRequest, to be in sync with the changes in .NET Adapter SDK code.
Also renamed RetrieveFilesDataRequestImpl to RepositoryFilesRequestImpl in order to be consistent.

NOTE: This PR must not be merged until https://github.com/FileAnalysisSuite/adaptersdk-interfaces/pull/5 is merged. 