### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 
     <groupId>io.github.fileanalysissuite.adaptersdk.impls.jaxrs</groupId>
     <artifactId>adaptersdk-impl-jaxrs</artifactId>
+    <name>adaptersdk-impl-jaxrs</name>
     <version>1.1.0-SNAPSHOT</version>
 
     <description>FAS Custom Adapter JAX-RS SDK Implementation</description>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210
